### PR TITLE
feat: add OpenTelemetry (OTEL) instrumentation support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ required_modifiable_fields:
   - custom_download_password
 
 app_name: file-storage
-__app_version: 23.1.17217
+__app_version: 26.4.25487
 
 main_class: "com.experitest.filestore.StorageFileMain"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ required_modifiable_fields:
   - custom_download_password
 
 app_name: file-storage
-__app_version: 26.4.25496
+__app_version: 26.4.25643
 
 main_class: "com.experitest.filestore.StorageFileMain"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ required_modifiable_fields:
   - custom_download_password
 
 app_name: file-storage
-__app_version: 26.6.25935
+__app_version: 23.1.17217
 
 main_class: "com.experitest.filestore.StorageFileMain"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ required_modifiable_fields:
   - custom_download_password
 
 app_name: file-storage
-__app_version: 26.4.25487
+__app_version: 26.4.25496
 
 main_class: "com.experitest.filestore.StorageFileMain"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ required_modifiable_fields:
   - custom_download_password
 
 app_name: file-storage
-__app_version: 26.4.25643
+__app_version: 26.6.25935
 
 main_class: "com.experitest.filestore.StorageFileMain"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,40 @@ __server_port: 8082
 
 __java_version: 17.0.18_8
 
+# OpenTelemetry Configuration
+otel_enabled: false
+otel_version: "2.23.0"
+otel_download_url: "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v{{ otel_version }}/opentelemetry-javaagent.jar"
+otel_jar_name: "opentelemetry-javaagent.jar"
+otel_jar_full_path: "{{ installation_root_folder }}/otel/{{ otel_jar_name }}"
+
+otel_service_name: "{{ app_name }}"
+otel_environment: "prod"
+otel_namespace: "daict"
+otel_customer: "default"
+otel_alloy_endpoint: "http://{{ otel_alloy_host }}:{{ otel_alloy_port }}"
+otel_alloy_host: "localhost"
+otel_alloy_port: 4317
+
+otel_java_options:
+  - "-javaagent:{{ otel_jar_full_path }}"
+  - "-Dotel.service.name={{ otel_service_name }}"
+  - "-Dotel.resource.attributes=deployment.environment={{ otel_environment }},service.namespace={{ otel_namespace }},customer={{ otel_customer }}"
+  - "-Dotel.exporter.otlp.endpoint={{ otel_alloy_endpoint }}"
+  - "-Dotel.exporter.otlp.protocol=grpc"
+  - "-Dotel.metrics.exporter=otlp"
+  - "-Dotel.logs.exporter=otlp"
+
+# Keep user-provided extra JVM options separate from OTEL options
 extra_java_options: []
+
+# Add OTEL options only when enabled
+enabled_otel_java_options: "{{ otel_java_options if otel_enabled else [] }}"
+
+base_java_options: []
+
+# Final JVM options used by startup scripts/templates
+java_options: "{{ base_java_options + extra_java_options + enabled_otel_java_options }}"
 
 __maximum_storage_size: "1TB"
 __maximum_file_size: "2GB"

--- a/tasks/linux-install.yml
+++ b/tasks/linux-install.yml
@@ -84,6 +84,22 @@
     owner: "{{ ansible_user_id }}"
   become: yes
 
+- name: Create directory for OTEL jar
+  file:
+    path: "{{ installation_root_folder }}/otel"
+    state: directory
+    owner: "{{ ansible_user_id }}"
+  become: yes
+  when: otel_enabled | bool
+
+- name: Download OpenTelemetry Java agent jar
+  get_url:
+    url: "{{ otel_download_url }}"
+    dest: "{{ otel_jar_full_path }}"
+    mode: '0644'
+    timeout: "{{ download_timeout | default(60) }}"
+  when: otel_enabled | bool
+
 - name: make sure unzip folder exist
   file:
     path: "{{ temp_folder }}/{{ (installer_file_name | splitext)[0] }}"

--- a/templates/start.bat.j2
+++ b/templates/start.bat.j2
@@ -12,5 +12,5 @@
     -Djdk.nio.maxCachedBufferSize=262144 ^
     -Djava.net.preferIPv4Stack=true ^
     -Djava.library.path=.;bin; ^
-    {{ extra_java_options | join(' ') }} ^
+    {{ java_options | join(' ') }} ^
     {{ main_class }}

--- a/templates/start.sh.j2
+++ b/templates/start.sh.j2
@@ -27,5 +27,5 @@ $JAVA_BIN -cp ".:lib/*" \
     -Djdk.nio.maxCachedBufferSize=262144 \
     -Djava.net.preferIPv4Stack=true \
     -Djava.library.path=.:bin: \
-    {{ extra_java_options | join(' ') }} \
+    {{ java_options | join(' ') }} \
     {{ main_class }}


### PR DESCRIPTION
## Summary
- Adds full OpenTelemetry signal correlation for traces, logs, and metrics via Grafana Alloy
- Fixes `stage.multiline` placement (moved to first stage) and corrects `firstline` regex to match actual Java log format (`YYYY-MM-DD HH:MM:SS`)
- Extracts only the `body` field from OTEL log JSON so Loki stores the raw log message instead of the full JSON envelope

## Test plan
- [ ] Deploy Alloy via Ansible and verify multiline Java stack traces are combined into single Loki entries
- [ ] Confirm OTEL logs in Loki contain only the log body (not the full JSON blob)
- [ ] Verify traces appear in Tempo with correct service graph metrics