### PR TITLE
Upgrade Java version to 25.0.4_7

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,7 +17,7 @@ main_class: "com.experitest.filestore.StorageFileMain"
 
 __server_port: 8082
 
-__java_version: 25.0.2_10
+__java_version: 25.0.4_7
 
 # OpenTelemetry Configuration
 otel_enabled: false


### PR DESCRIPTION
Upgrades the Java version to **25.0.4_7** to standardize on a single version across all Ansible roles.

- Updated `__java_version` in `defaults/main.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)